### PR TITLE
Fixed typo in SUSE manager role label

### DIFF
--- a/package/installation.suse-manager-server.xsl
+++ b/package/installation.suse-manager-server.xsl
@@ -860,7 +860,7 @@ For now it simply copies all XML tags to the target file.
   <xsl:template xml:space="preserve" match="n:minimal_role">
     <suma_role>
       <!-- TRANSLATORS: a label for a system role -->
-      <label>SUSE Manager Server (sigle disk)</label>
+      <label>SUSE Manager Server (single disk)</label>
     </suma_role>
     <suma_role_description>
       <label>• Manager Server pattern
@@ -869,7 +869,7 @@ For now it simply copies all XML tags to the target file.
 
     <suma_retail_role>
       <!-- TRANSLATORS: a label for a system role -->
-      <label>SUSE Manager for Retail Server (sigle disk)</label>
+      <label>SUSE Manager for Retail Server (single disk)</label>
     </suma_retail_role>
     <suma_retail_role_description>
       <label>• Retail Server Pattern

--- a/package/skelcd-control-suse-manager-server.changes
+++ b/package/skelcd-control-suse-manager-server.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri May 15 07:59:21 UTC 2020 - Michal Filka <mchf@suse.cz>
+
+- bnc#1171667
+  - fixed typo in SUSE Manager role label
+- 4.1.4
+
+-------------------------------------------------------------------
 Fri Apr 17 08:53:01 UTC 2020 - David Diaz <dgonzalez@suse.com>
 
 - Fix file format and validation adding missing elements and attributes

--- a/package/skelcd-control-suse-manager-server.spec
+++ b/package/skelcd-control-suse-manager-server.spec
@@ -60,7 +60,7 @@ Provides:       system-installation() = SUSE-Manager-Server
 Url:            https://github.com/yast/skelcd-control-suse-manager-server
 AutoReqProv:    off
 # IMPORTANT: This needs to be 4.1.0 as it is the SUSE Manager version!
-Version:        4.1.3
+Version:        4.1.4
 Release:        0
 Summary:        SUSE Manager Server control file needed for installation
 License:        MIT


### PR DESCRIPTION
https://bugzilla.suse.com/show_bug.cgi?id=1171667