### PR TITLE
Adapt to simplified workflow

### DIFF
--- a/package/skelcd-control-suse-manager-server.changes
+++ b/package/skelcd-control-suse-manager-server.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Dec  3 14:43:29 UTC 2021 - David Diaz <dgonzalez@suse.com>
+
+- Update dependency on skelcd-control-SLES to version 15.4.1 to
+  remove the registration step (bsc#1193311).
+- 4.3.1
+
+-------------------------------------------------------------------
 Tue Oct 19 08:26:44 UTC 2021 - Julio González Gil <jgonzalez@suse.com>
 
 - Version 4.3.0:

--- a/package/skelcd-control-suse-manager-server.spec
+++ b/package/skelcd-control-suse-manager-server.spec
@@ -37,9 +37,10 @@ BuildRequires:  libxml2-tools
 # Added skelcd macros
 BuildRequires:  yast2-installation-control >= 4.1.5
 
-# Original SLES control file (skip registration)
+# Original SLES control file
+# (simplified workflow - https://github.com/yast/skelcd-control-SLES/pull/142)
 BuildRequires:  diffutils
-BuildRequires:  skelcd-control-SLES >= 15.2.0
+BuildRequires:  skelcd-control-SLES >= 15.4.1
 
 # for building we do not need all skelcd-control-SLES dependencies
 #!BuildIgnore: yast2-registration yast2-theme yast2 autoyast2 yast2-add-on yast2-buildtools

--- a/package/skelcd-control-suse-manager-server.spec
+++ b/package/skelcd-control-suse-manager-server.spec
@@ -61,7 +61,7 @@ Provides:       system-installation() = SUSE-Manager-Server
 URL:            https://github.com/yast/skelcd-control-suse-manager-server
 AutoReqProv:    off
 # IMPORTANT: This needs to be 4.3.0 as it is the SUSE Manager version!
-Version:        4.3.0
+Version:        4.3.1
 Release:        0
 Summary:        SUSE Manager Server control file needed for installation
 License:        MIT


### PR DESCRIPTION
Same than https://github.com/yast/skelcd-control-suse-manager-proxy/pull/19 but for SUSE Manager server.

> ## Problem
> 
> The installation workflow has been simplified (see https://github.com/yast/skelcd-control-leanos/pull/83, https://github.com/yast/skelcd-control-leanos/pull/84, and https://github.com/yast/skelcd-control-SLES/pull/141) but the dependency of this control file in skelcd-control-SLES has not been updated yet, which makes possible to get the registration step twice. See https://bugzilla.suse.com/show_bug.cgi?id=1193311.
> 
> ## Solution
> 
> Update dependency on skelcd-control-SLES to 15.4.1
