### PR TITLE
fix setting default module section in installation control file

### DIFF
--- a/package/installation.suse-manager-server.xsl
+++ b/package/installation.suse-manager-server.xsl
@@ -909,7 +909,6 @@ textdomain="control"
   <xsl:template xml:space="preserve" match="n:software/n:default_modules">
         <default_modules config:type="list">
             <default_module>sle-module-basesystem</default_module>
-            <default_module>sle-module-python2</default_module>
             <default_module>sle-module-server-applications</default_module>
             <default_module>sle-module-web-scripting</default_module>
             <default_module>sle-module-suse-manager-server</default_module>

--- a/package/installation.suse-manager-server.xsl
+++ b/package/installation.suse-manager-server.xsl
@@ -905,19 +905,14 @@ textdomain="control"
 
   </xsl:template>
 
-  <!-- add a new "software/default_modules" section just after the "textdomain" -->
-  <xsl:template xml:space="preserve" match="n:textdomain">
-    <xsl:copy>
-      <xsl:apply-templates/>
-    </xsl:copy>
-    <software>
-      <xsl:comment> the default preselected modules in offline installation </xsl:comment>
-      <default_modules config:type="list">
-        <default_module>sle-module-basesystem</default_module>
-        <default_module>sle-module-python2</default_module>
-        <default_module>sle-module-server-applications</default_module>
-        <default_module>sle-module-web-scripting</default_module>
-      </default_modules>
-    </software>
+  <!-- modify the default modules -->
+  <xsl:template xml:space="preserve" match="n:software/n:default_modules">
+        <default_modules config:type="list">
+            <default_module>sle-module-basesystem</default_module>
+            <default_module>sle-module-python2</default_module>
+            <default_module>sle-module-server-applications</default_module>
+            <default_module>sle-module-web-scripting</default_module>
+            <default_module>sle-module-suse-manager-server</default_module>
+        </default_modules>
   </xsl:template>
 </xsl:stylesheet>

--- a/package/skelcd-control-suse-manager-server.changes
+++ b/package/skelcd-control-suse-manager-server.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Jan 10 09:34:39 UTC 2023 - Michael Calmer <mc@suse.com>
+
+- fix setting default module section in installation control file
+  (bsc#1203294)
+
+-------------------------------------------------------------------
 Mon Nov  7 12:32:34 UTC 2022 - Julio González Gil <jgonzalez@suse.com>
 
 - Version 4.4.0

--- a/package/skelcd-control-suse-manager-server.changes
+++ b/package/skelcd-control-suse-manager-server.changes
@@ -1,14 +1,20 @@
 -------------------------------------------------------------------
-Tue Jan 10 09:34:39 UTC 2023 - Michael Calmer <mc@suse.com>
-
-- fix setting default module section in installation control file
-  (bsc#1203294)
-
--------------------------------------------------------------------
 Mon Nov  7 12:32:34 UTC 2022 - Julio González Gil <jgonzalez@suse.com>
 
 - Version 4.4.0
   * SUSE Manager version 4.4.0 (bsc#1206557)
+
+-------------------------------------------------------------------
+Tue Sep 20 13:23:29 UTC 2022 - Michael Calmer <mc@suse.com>
+
+- remove python2 module not supported and not needed in
+  SLE15 SP4 and SUSE Manager Server 4.3
+
+-------------------------------------------------------------------
+Fri Sep 16 07:28:15 UTC 2022 - Michael Calmer <mc@suse.com>
+
+- fix setting default module section in installation control file
+  (bsc#1203294)
 
 -------------------------------------------------------------------
 Wed Apr 06 13:24:58 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>


### PR DESCRIPTION
## Problem

Default module selection using Full image does not work.

- https://bugzilla.suse.com/show_bug.cgi?id=1203294
- https://github.com/yast/skelcd-control-suse-manager-proxy/pull/21


## Solution

The template has already a section for default modules.
The XSL file just add a second section and YaST seems to take the "last" one specified which is the original from the template.

This PR modify/replace the existing section.

## Testing

- *Tested manually*

